### PR TITLE
Adds integration with pytest-timeout

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,5 @@
 pylint
 pytest
 pytest-cov
+pytest-timeout
 ..


### PR DESCRIPTION
Fixes #2

Basically, integration tests should not be slow, otherwise
they are slow_integration tests.

By default, there is no value set, as "slow" is very much
relative to what your project is doing.