### PR TITLE
Add support for tests marked xfail

### DIFF
--- a/pytest_integration/pytest_plugin.py
+++ b/pytest_integration/pytest_plugin.py
@@ -123,7 +123,9 @@ def pytest_runtest_makereport(item, call):
     Turns of running (quick) integration tests or integration tests
     if one of the previous stages failed.
     """
-
+    if item.get_closest_marker("xfail"):
+        return
+    
     if not call.excinfo or call.excinfo.value.__class__.__name__ == 'Skipped':
         return
 


### PR DESCRIPTION
As it stands, pytest-integration will turn off slow_integration and integration tests if it encounters a test marked xfail (as `call.excinfo` will exist and raises `ValueError` in our case, rather than `Skipped`)

The solution is simple: Return early from `pytest_runtest_makereport` if you find the closest `xfail` marker.