### PR TITLE
Now uses "pytest_integration" as pytest plugin name instead of "name_…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=['pytest_integration'],
     # the following makes a plugin available to pytest
     entry_points={
-        'pytest11': ['name_of_plugin = pytest_integration.pytest_plugin'],
+        'pytest11': ['pytest_integration = pytest_integration.pytest_plugin'],
     },
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
…of_plugin"

The name of the plugin was copied from the [pytest documentation](https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#making-your-plugin-installable-by-others) but wasn't changed.